### PR TITLE
process false return value properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/netDalek/json-rpc-objects.git
-  revision: 6ff3067c48caca06c0cea85e6094b3455b595f98
+  revision: 87b3aae6fe1c1f3c756bc92f68307203bda4b4d6
   specs:
     json-rpc-objects (0.4.3)
       abstract (>= 1.0.0)

--- a/lib/ferryman/client.rb
+++ b/lib/ferryman/client.rb
@@ -33,7 +33,8 @@ module Ferryman
         _key, raw_response = @redis.blpop(key, timeout: @timeout)
         raise Timeout::Error, "timeout for method #{method} with arguments #{arguments}" if raw_response.nil?
         response = JsonRpcObjects::Response.parse(raw_response)
-        response.result || raise(Ferryman::Error.new(response.error))
+        raise(Ferryman::Error.new(response.error)) if response.error
+        response.result
       end
     end
 

--- a/spec/ferryman_spec.rb
+++ b/spec/ferryman_spec.rb
@@ -10,6 +10,9 @@ describe "ferryman" do
     def sum(a, b)
       a + b
     end
+    def even(n)
+      n.even?
+    end
     def long
       sleep(2)
     end
@@ -28,6 +31,8 @@ describe "ferryman" do
     end
     sleep(10)
 
+    expect(client.call(:even, 3)).to eql(false)
+    expect(client.call(:even, 2)).to eql(true)
     expect(client.call(:sum, 1, 2)).to eql(3)
     expect(client.cast(:sum, 1, 2)).to eql(1)
     expect(client.multicall(:sum, 1, 2)).to eql([3])


### PR DESCRIPTION
There used to be a problem with returning `false` value from RPC service, because in this case error was mistakenly raised with `null` message.