### PR TITLE
remove active support delegate usage to fix running tests

### DIFF
--- a/lib/ferryman/rpc/result.rb
+++ b/lib/ferryman/rpc/result.rb
@@ -2,15 +2,18 @@ module Ferryman
   module Rpc
     class Result
       attr_reader :message, :redis, :key, :default_timeout, :results_count, :order
-      delegate :channel, to: :message
 
       def initialize(message, redis, key, default_timeout, results_count, order = nil)
         @message = message
         @redis = redis
-        @key = key 
+        @key = key
         @default_timeout = default_timeout
         @results_count = results_count
         @order = order
+      end
+
+      def channel
+        message.channel
       end
 
       def result(timeout = nil)


### PR DESCRIPTION
Tests are not able to run with usage of `delegate` from rails active support gem.
Tests are still don't pass, but it let's eat elephant by parts, and fix running first.

Without this fix you will get 

```
# bundle exec rspec

An error occurred while loading ./spec/ferryman_spec.rb.
Failure/Error: delegate :channel, to: :message

NoMethodError:
  undefined method `delegate' for Ferryman::Rpc::Result:Class
# ./lib/ferryman/rpc/result.rb:5:in `<class:Result>'

```